### PR TITLE
Add example Qdrant connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+QDRANT_URL=http://localhost:6333
+QDRANT_API_KEY=your-api-key-if-needed

--- a/Code/qdrant_rag_connection.py
+++ b/Code/qdrant_rag_connection.py
@@ -1,0 +1,27 @@
+import os
+from qdrant_client import QdrantClient
+from dotenv import load_dotenv
+
+
+def get_qdrant_client() -> QdrantClient:
+    """Create and return a Qdrant client using credentials from .env."""
+    load_dotenv()
+
+    url = os.getenv("QDRANT_URL")
+    api_key = os.getenv("QDRANT_API_KEY")
+
+    if not url:
+        raise ValueError("QDRANT_URL is not set in the environment")
+
+    # api_key may be optional if qdrant does not require it
+    return QdrantClient(url=url, api_key=api_key)
+
+
+if __name__ == "__main__":
+    client = get_qdrant_client()
+    # Example health check request
+    try:
+        info = client.get_liveness()
+        print("Qdrant is alive:" if info else "No response from Qdrant")
+    except Exception as exc:
+        print(f"Failed to connect to Qdrant: {exc}")

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Datenbanken
+
 Datenbanken_Portfolio
+
+## Qdrant RAG Connection
+
+This repository contains a small example of how to connect to a Qdrant
+vector database as part of a retrieval augmented generation (RAG) system.
+The `Code/qdrant_rag_connection.py` script reads connection settings from
+a `.env` file using [`python-dotenv`](https://pypi.org/project/python-dotenv/)
+and instantiates a `QdrantClient` from the [`qdrant-client`](https://pypi.org/project/qdrant-client/) package.
+
+Create a `.env` file in the project root with the following variables:
+
+```bash
+QDRANT_URL=<http://localhost:6333>
+QDRANT_API_KEY=<your-api-key-if-needed>
+```
+
+Install the required packages and run the script:
+
+```bash
+pip install qdrant-client python-dotenv
+python Code/qdrant_rag_connection.py
+```
+
+The script performs a simple liveness check to verify that Qdrant is
+reachable.


### PR DESCRIPTION
## Summary
- add sample script connecting to Qdrant using environment variables
- document how to use qdrant connection in README
- provide `.env.example` file with expected variables

## Testing
- `python Code/qdrant_rag_connection.py` *(fails: ModuleNotFoundError: No module named 'qdrant_client')*

------
https://chatgpt.com/codex/tasks/task_e_684d70d424c083258e170fefa3f81a27