### PR TITLE
Add Flask web frontend for Qdrant demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Uploaded PDFs
+uploads/
+

--- a/Code/qdrant_utils.py
+++ b/Code/qdrant_utils.py
@@ -1,0 +1,92 @@
+import os
+from typing import List
+
+import fitz
+from dotenv import load_dotenv
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct, VectorParams, Distance
+from openai import OpenAI
+
+
+def get_qdrant_client() -> QdrantClient:
+    load_dotenv()
+    host = os.getenv("QDRANT_SERVER_IP", "localhost")
+    port = int(os.getenv("QDRANT_PORT", 6333))
+    return QdrantClient(host=host, port=port)
+
+
+def load_pdf_and_chunk(filepath: str, chunk_size: int = 500, overlap: int = 50) -> List[str]:
+    if not os.path.exists(filepath):
+        raise FileNotFoundError(f"The file was not found: {filepath}")
+
+    doc = fitz.open(filepath)
+    full_text = ""
+    for page in doc:
+        full_text += page.get_text("text") + "\n"
+    doc.close()
+
+    chunks = []
+    start = 0
+    while start < len(full_text):
+        end = min(start + chunk_size, len(full_text))
+        chunks.append(full_text[start:end])
+        start += chunk_size - overlap
+
+    return chunks
+
+
+def get_embedding(text: str, model: str = "text-embedding-3-large") -> List[float]:
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY was not found in the .env file.")
+
+    client = OpenAI(api_key=api_key)
+    response = client.embeddings.create(input=text, model=model)
+    return response.data[0].embedding
+
+
+def embed_chunks(chunks: List[str]) -> List[List[float]]:
+    return [get_embedding(chunk) for chunk in chunks]
+
+
+def store_embeddings_in_qdrant(client: QdrantClient, collection_name: str, chunks: List[str], embeddings: List[List[float]]):
+    client.recreate_collection(
+        collection_name=collection_name,
+        vectors_config=VectorParams(size=len(embeddings[0]), distance=Distance.COSINE)
+    )
+    points = [
+        PointStruct(id=i, vector=vector, payload={"text": chunks[i]})
+        for i, vector in enumerate(embeddings)
+    ]
+    client.upsert(collection_name=collection_name, points=points)
+
+
+def retrieve_similar_chunks(query: str, client: QdrantClient, collection_name: str, top_k: int = 5) -> List[str]:
+    query_vector = get_embedding(query)
+    search_result = client.search(
+        collection_name=collection_name,
+        query_vector=query_vector,
+        limit=top_k
+    )
+    return [hit.payload["text"] for hit in search_result]
+
+
+def answer_with_context(query: str, context_chunks: List[str], model: str = "gpt-4o") -> str:
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY was not found in the .env file.")
+
+    client = OpenAI(api_key=api_key)
+    context = "\n\n".join(context_chunks)
+    prompt = f"Answer the following question based on the context:\n\nContext:\n{context}\n\nQuestion: {query}"
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant for scientific questions."},
+            {"role": "user", "content": prompt}
+        ],
+        temperature=0.2
+    )
+    return response.choices[0].message.content.strip()

--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ python Code/qdrant_rag_connection.py
 
 The script performs a simple liveness check to verify that Qdrant is
 reachable.
+
+## Web Interface
+
+A small Flask application is provided in `app.py` to upload a PDF, ask a
+question and display the answer generated with the stored embeddings. To
+run the web app install the dependencies and start the server:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Ensure the `.env` file contains the required `QDRANT_SERVER_IP`,
+`QDRANT_PORT` and `OPENAI_API_KEY` variables. The app will be available at
+`http://localhost:5000/`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+import os
+from tempfile import NamedTemporaryFile
+
+from flask import Flask, render_template, request
+from werkzeug.utils import secure_filename
+
+from Code.qdrant_utils import (
+    get_qdrant_client,
+    load_pdf_and_chunk,
+    embed_chunks,
+    store_embeddings_in_qdrant,
+    retrieve_similar_chunks,
+    answer_with_context,
+)
+
+app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16 MB limit
+
+COLLECTION_NAME = "webapp_collection"
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    answer = None
+    if request.method == "POST":
+        file = request.files.get("document")
+        query = request.form.get("query", "")
+        client = get_qdrant_client()
+
+        if file and file.filename:
+            filename = secure_filename(file.filename)
+            with NamedTemporaryFile(delete=False, suffix=os.path.splitext(filename)[1]) as tmp:
+                file.save(tmp.name)
+                chunks = load_pdf_and_chunk(tmp.name)
+                embeddings = embed_chunks(chunks)
+                store_embeddings_in_qdrant(client, COLLECTION_NAME, chunks, embeddings)
+            os.remove(tmp.name)
+
+        if query:
+            retrieved = retrieve_similar_chunks(query, client, COLLECTION_NAME, top_k=5)
+            answer = answer_with_context(query, retrieved)
+
+    return render_template("index.html", answer=answer)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+qdrant-client
+python-dotenv
+openai
+PyMuPDF

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,44 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f7f7f7;
+    margin: 0;
+    padding: 40px;
+}
+
+.container {
+    max-width: 600px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+label {
+    display: block;
+    margin-top: 15px;
+    margin-bottom: 5px;
+}
+
+input[type="text"], input[type="file"] {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+}
+
+button {
+    padding: 10px 20px;
+    background-color: #007BFF;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.answer {
+    margin-top: 20px;
+    background: #eef;
+    padding: 15px;
+    border-radius: 4px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Qdrant RAG Demo</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    <h1>Qdrant RAG Demo</h1>
+    <form method="post" enctype="multipart/form-data">
+        <label for="document">PDF Document</label>
+        <input type="file" name="document" id="document" accept="application/pdf">
+
+        <label for="query">Prompt</label>
+        <input type="text" name="query" id="query" placeholder="Ask a question" required>
+
+        <button type="submit">Submit</button>
+    </form>
+
+    {% if answer %}
+    <div class="answer">
+        <h2>Answer</h2>
+        <p>{{ answer }}</p>
+    </div>
+    {% endif %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement simple web interface with Flask to upload PDFs and submit prompts
- add utility module derived from notebook
- include basic HTML template and CSS
- provide requirements.txt and update README instructions
- ignore uploaded files in .gitignore

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685d24b056a08330a6b451c4b7c5c542