### PR TITLE
Handle missing qdrant collection and polish UI

### DIFF
--- a/Code/qdrant_utils.py
+++ b/Code/qdrant_utils.py
@@ -63,11 +63,20 @@ def store_embeddings_in_qdrant(client: QdrantClient, collection_name: str, chunk
 
 
 def retrieve_similar_chunks(query: str, client: QdrantClient, collection_name: str, top_k: int = 5) -> List[str]:
+    """Return the most similar chunks for the given query.
+
+    If the collection does not exist yet, an empty list is returned in order
+    to avoid triggering a 404 error from Qdrant.
+    """
+
+    if not client.collection_exists(collection_name):
+        return []
+
     query_vector = get_embedding(query)
     search_result = client.search(
         collection_name=collection_name,
         query_vector=query_vector,
-        limit=top_k
+        limit=top_k,
     )
     return [hit.payload["text"] for hit in search_result]
 

--- a/app.py
+++ b/app.py
@@ -38,7 +38,10 @@ def index():
 
         if query:
             retrieved = retrieve_similar_chunks(query, client, COLLECTION_NAME, top_k=5)
-            answer = answer_with_context(query, retrieved)
+            if not retrieved:
+                answer = "No documents available. Please upload a PDF first."
+            else:
+                answer = answer_with_context(query, retrieved)
 
     return render_template("index.html", answer=answer)
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,13 @@
+:root {
+    --primary-color: #007BFF;
+    --secondary-color: #0056b3;
+    --background-color: #f7f7f7;
+    --container-bg: #ffffff;
+}
+
 body {
     font-family: Arial, sans-serif;
-    background-color: #f7f7f7;
+    background-color: var(--background-color);
     margin: 0;
     padding: 40px;
 }
@@ -8,10 +15,10 @@ body {
 .container {
     max-width: 600px;
     margin: auto;
-    background: #fff;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    background: var(--container-bg);
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 label {
@@ -25,20 +32,42 @@ input[type="text"], input[type="file"] {
     padding: 8px;
     margin-bottom: 10px;
     box-sizing: border-box;
+    border: 1px solid #ccc;
+    border-radius: 4px;
 }
 
-button {
+input[type="file"]::file-selector-button {
+    background-color: var(--primary-color);
+    color: #fff;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+input[type="file"]::file-selector-button:hover {
+    background-color: var(--secondary-color);
+}
+
+.btn {
     padding: 10px 20px;
-    background-color: #007BFF;
+    background-color: var(--primary-color);
     color: #fff;
     border: none;
     border-radius: 4px;
     cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.btn:hover {
+    background-color: var(--secondary-color);
 }
 
 .answer {
     margin-top: 20px;
     background: #eef;
     padding: 15px;
-    border-radius: 4px;
+    border-radius: 6px;
+    border: 1px solid #dde;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,14 +8,14 @@
 <body>
 <div class="container">
     <h1>Qdrant RAG Demo</h1>
-    <form method="post" enctype="multipart/form-data">
+    <form method="post" enctype="multipart/form-data" class="form">
         <label for="document">PDF Document</label>
         <input type="file" name="document" id="document" accept="application/pdf">
 
         <label for="query">Prompt</label>
         <input type="text" name="query" id="query" placeholder="Ask a question" required>
 
-        <button type="submit">Submit</button>
+        <button type="submit" class="btn">Submit</button>
     </form>
 
     {% if answer %}


### PR DESCRIPTION
## Summary
- avoid `404` when the collection does not exist by checking `collection_exists`
- show a message if no documents are available
- polish the UI with a consistent colour scheme, rounded corners and hover effects

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685d290fb100833083d2daf4c39f22df