### PR TITLE
Update RAG web app forms and PDF loading

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,13 +9,17 @@
 <div class="container">
     <h1>Qdrant RAG Demo</h1>
     <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="form_type" value="upload">
         <label for="document">PDF Document</label>
         <input type="file" name="document" id="document" accept="application/pdf">
+        <button type="submit">Upload Document</button>
+    </form>
 
+    <form method="post">
+        <input type="hidden" name="form_type" value="query">
         <label for="query">Prompt</label>
         <input type="text" name="query" id="query" placeholder="Ask a question" required>
-
-        <button type="submit">Submit</button>
+        <button type="submit">Ask Question</button>
     </form>
 
     {% if error %}


### PR DESCRIPTION
## Summary
- split document upload and query into separate forms
- handle missing `fitz.open` error gracefully and fallback
- avoid recreating collections when adding new documents

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685d2b8ca16883308d1a87e19309d63f