### PR TITLE
Improve RAG demo

### DIFF
--- a/Code/qdrant_utils.py
+++ b/Code/qdrant_utils.py
@@ -1,11 +1,11 @@
 import os
 from typing import List
 
-import fitz
 from dotenv import load_dotenv
 from qdrant_client import QdrantClient
 from qdrant_client.models import PointStruct, VectorParams, Distance
 from openai import OpenAI
+import numpy as np
 
 
 def get_qdrant_client() -> QdrantClient:
@@ -18,6 +18,11 @@ def get_qdrant_client() -> QdrantClient:
 def load_pdf_and_chunk(filepath: str, chunk_size: int = 500, overlap: int = 50) -> List[str]:
     if not os.path.exists(filepath):
         raise FileNotFoundError(f"The file was not found: {filepath}")
+
+    try:
+        import fitz  # PyMuPDF
+    except Exception as exc:
+        raise ImportError("PyMuPDF is required to process PDF files.") from exc
 
     doc = fitz.open(filepath)
     full_text = ""
@@ -36,14 +41,24 @@ def load_pdf_and_chunk(filepath: str, chunk_size: int = 500, overlap: int = 50) 
 
 
 def get_embedding(text: str, model: str = "text-embedding-3-large") -> List[float]:
+    """Return an embedding for the given text.
+
+    If an ``OPENAI_API_KEY`` is present in the environment, the OpenAI API is
+    used. Otherwise a simple deterministic fallback embedding is generated so
+    the demo can run without external tokens.
+    """
     load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("OPENAI_API_KEY was not found in the .env file.")
+    if api_key:
+        client = OpenAI(api_key=api_key)
+        response = client.embeddings.create(input=text, model=model)
+        return response.data[0].embedding
 
-    client = OpenAI(api_key=api_key)
-    response = client.embeddings.create(input=text, model=model)
-    return response.data[0].embedding
+    # fallback: deterministic embedding based on byte values
+    vector = np.zeros(512, dtype=float)
+    for i, b in enumerate(text.encode("utf-8")):
+        vector[i % 512] += float(b)
+    return vector.tolist()
 
 
 def embed_chunks(chunks: List[str]) -> List[List[float]]:
@@ -51,12 +66,18 @@ def embed_chunks(chunks: List[str]) -> List[List[float]]:
 
 
 def store_embeddings_in_qdrant(client: QdrantClient, collection_name: str, chunks: List[str], embeddings: List[List[float]]):
-    client.recreate_collection(
-        collection_name=collection_name,
-        vectors_config=VectorParams(size=len(embeddings[0]), distance=Distance.COSINE)
-    )
+    collections = client.get_collections().collections
+    if collection_name not in [c.name for c in collections]:
+        client.recreate_collection(
+            collection_name=collection_name,
+            vectors_config=VectorParams(size=len(embeddings[0]), distance=Distance.COSINE)
+        )
+        next_id = 0
+    else:
+        next_id = client.count(collection_name=collection_name, exact=True).count
+
     points = [
-        PointStruct(id=i, vector=vector, payload={"text": chunks[i]})
+        PointStruct(id=next_id + i, vector=vector, payload={"text": chunks[i]})
         for i, vector in enumerate(embeddings)
     ]
     client.upsert(collection_name=collection_name, points=points)
@@ -65,34 +86,44 @@ def store_embeddings_in_qdrant(client: QdrantClient, collection_name: str, chunk
 def retrieve_similar_chunks(query: str, client: QdrantClient, collection_name: str, top_k: int = 5) -> List[str]:
     collections = client.get_collections().collections
     if collection_name not in [c.name for c in collections]:
-        raise ValueError(
-            f"Collection '{collection_name}' not found. Please upload a document first."
-        )
+        # no collection yet, nothing to retrieve
+        return []
 
     query_vector = get_embedding(query)
     search_result = client.search(
         collection_name=collection_name,
         query_vector=query_vector,
-        limit=top_k
+        limit=top_k,
     )
     return [hit.payload["text"] for hit in search_result]
 
 
 def answer_with_context(query: str, context_chunks: List[str], model: str = "gpt-4o") -> str:
+    """Generate an answer for ``query`` using the provided ``context_chunks``.
+
+    When an OpenAI API key is available, the GPT model is queried. If not, the
+    context is returned verbatim so the application remains usable without
+    external services.
+    """
     load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("OPENAI_API_KEY was not found in the .env file.")
 
-    client = OpenAI(api_key=api_key)
     context = "\n\n".join(context_chunks)
-    prompt = f"Answer the following question based on the context:\n\nContext:\n{context}\n\nQuestion: {query}"
-    response = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant for scientific questions."},
-            {"role": "user", "content": prompt}
-        ],
-        temperature=0.2
-    )
-    return response.choices[0].message.content.strip()
+
+    if api_key:
+        client = OpenAI(api_key=api_key)
+        prompt = (
+            f"Answer the following question based on the context:\n\nContext:\n{context}\n\nQuestion: {query}"
+        )
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant for scientific questions."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.2,
+        )
+        return response.choices[0].message.content.strip()
+
+    # fallback: return raw context when no API key is configured
+    return f"Context:\n{context}\n\nQuestion: {query}"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ reachable.
 
 ## Web Interface
 
-A small Flask application is provided in `app.py` to upload a PDF, ask a
-question and display the answer generated with the stored embeddings. To
+The repository contains a small Flask application in `app.py` for uploading
+PDFs and submitting questions. Uploaded documents are chunked and embedded and
+stored in Qdrant. Questions can then be asked against this vector store. The
+web interface now exposes **two** separate forms: one for uploading a document
+and one for sending a query.
+
+To
 run the web app install the dependencies and start the server:
 
 ```bash
@@ -39,5 +44,8 @@ python app.py
 ```
 
 Ensure the `.env` file contains the required `QDRANT_SERVER_IP`,
-`QDRANT_PORT` and `OPENAI_API_KEY` variables. The app will be available at
+`QDRANT_PORT` and optionally `OPENAI_API_KEY` variables. When no OpenAI key is
+set the application will fall back to simple local embeddings and return the
+retrieved context directly.
+The app will be available at
 `http://localhost:5000/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ qdrant-client
 python-dotenv
 openai
 PyMuPDF
+numpy

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,14 +8,16 @@
 <body>
 <div class="container">
     <h1>Qdrant RAG Demo</h1>
-    <form method="post" enctype="multipart/form-data">
+    <form method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data" class="upload-form">
         <label for="document">PDF Document</label>
         <input type="file" name="document" id="document" accept="application/pdf">
+        <button type="submit">Upload</button>
+    </form>
 
+    <form method="post" action="{{ url_for('query') }}" class="query-form">
         <label for="query">Prompt</label>
         <input type="text" name="query" id="query" placeholder="Ask a question" required>
-
-        <button type="submit">Submit</button>
+        <button type="submit">Ask</button>
     </form>
 
     {% if error %}


### PR DESCRIPTION
## Summary
- separate upload and query routes
- fall back to local embeddings when OPENAI_API_KEY is missing
- handle missing PyMuPDF install cleanly
- retain uploaded documents across sessions and skip retrieval when empty
- document new behaviour in README
- add numpy requirement

## Testing
- `python3 -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685d2b8ca16883308d1a87e19309d63f