### PR TITLE
Fix PDF loading with PyPDF2

### DIFF
--- a/Code/qdrant_utils.py
+++ b/Code/qdrant_utils.py
@@ -20,15 +20,16 @@ def load_pdf_and_chunk(filepath: str, chunk_size: int = 500, overlap: int = 50) 
         raise FileNotFoundError(f"The file was not found: {filepath}")
 
     try:
-        import fitz  # PyMuPDF
+        from PyPDF2 import PdfReader
     except Exception as exc:
-        raise ImportError("PyMuPDF is required to process PDF files.") from exc
+        raise ImportError("PyPDF2 is required to process PDF files.") from exc
 
-    doc = fitz.open(filepath)
+    reader = PdfReader(filepath)
     full_text = ""
-    for page in doc:
-        full_text += page.get_text("text") + "\n"
-    doc.close()
+    for page in reader.pages:
+        text = page.extract_text()
+        if text:
+            full_text += text + "\n"
 
     chunks = []
     start = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Flask
 qdrant-client
 python-dotenv
 openai
-PyMuPDF
+PyPDF2
 numpy


### PR DESCRIPTION
## Summary
- switch PDF parser from PyMuPDF to PyPDF2 in `load_pdf_and_chunk`
- update dependencies

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not connect to pypi.org)*
- `python -m py_compile app.py Code/qdrant_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685d2f5971008330b1bb190440b13e28