### PR TITLE
Add response input form

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ reachable.
 The repository contains a small Flask application in `app.py` for uploading
 PDFs and submitting questions. Uploaded documents are chunked and embedded and
 stored in Qdrant. Questions can then be asked against this vector store. The
-web interface now exposes **two** separate forms: one for uploading a document
-and one for sending a query.
+ web interface now exposes **three** separate forms: one for uploading a document,
+ one for sending a query and one for replying to the generated answer.
 
 To
 run the web app install the dependencies and start the server:

--- a/app.py
+++ b/app.py
@@ -54,5 +54,12 @@ def query():
     return render_template("index.html", answer=answer, error=error)
 
 
+@app.route("/respond", methods=["POST"])
+def respond():
+    answer = request.form.get("answer", "")
+    user_response = request.form.get("response", "")
+    return render_template("index.html", answer=answer, user_response=user_response, error=None)
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/static/style.css
+++ b/static/style.css
@@ -79,3 +79,20 @@ button:hover {
     border-radius: 4px;
     border: 1px solid #ebccd1;
 }
+
+textarea {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    resize: vertical;
+}
+
+.user-response {
+    margin-top: 20px;
+    background: #efe;
+    padding: 15px;
+    border-radius: 4px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,18 @@
         <h2>Answer</h2>
         <p>{{ answer }}</p>
     </div>
+    <form method="post" action="{{ url_for('respond') }}" class="response-form">
+        <input type="hidden" name="answer" value="{{ answer }}">
+        <label for="response">Deine Antwort</label>
+        <textarea name="response" id="response" rows="3" placeholder="Reply to the answer" required></textarea>
+        <button type="submit">Send</button>
+    </form>
+    {% endif %}
+    {% if user_response %}
+    <div class="user-response">
+        <h2>Your Response</h2>
+        <p>{{ user_response }}</p>
+    </div>
     {% endif %}
 </div>
 </body>


### PR DESCRIPTION
## Summary
- allow replying to generated answers
- show user responses on the main page
- style textarea and response section
- mention new response form in README

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685e55a07fc88325b988883b3d1df941