### PR TITLE
Enable multi-turn chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ reachable.
 ## Web Interface
 
 The repository contains a small Flask application in `app.py` for uploading
-PDFs and submitting questions. Uploaded documents are chunked and embedded and
-stored in Qdrant. Questions can then be asked against this vector store. The
- web interface now exposes **three** separate forms: one for uploading a document,
- one for sending a query and one for replying to the generated answer.
+PDFs and submitting questions. Uploaded documents are chunked, embedded and
+stored in Qdrant. Questions can then be asked against this vector store.
+The web interface exposes **three** forms: one for uploading a document, one
+for sending a query and one for replying to the generated answer. Replies are
+added to a persistent chat history which is sent as additional context for
+follow-up questions.
 
 To
 run the web app install the dependencies and start the server:

--- a/static/style.css
+++ b/static/style.css
@@ -96,3 +96,13 @@ textarea {
     padding: 15px;
     border-radius: 4px;
 }
+
+.chat-history {
+    margin-top: 20px;
+    background: #fafafa;
+    padding: 15px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    max-height: 300px;
+    overflow-y: auto;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,15 @@
         <button type="submit">Ask</button>
     </form>
 
+    {% if chat_history %}
+    <div class="chat-history">
+        <h2>Chat History</h2>
+        {% for msg in chat_history %}
+        <p><strong>{{ msg.role.capitalize() }}:</strong> {{ msg.content }}</p>
+        {% endfor %}
+    </div>
+    {% endif %}
+
     {% if error %}
     <div class="error">
         <p>{{ error }}</p>
@@ -32,17 +41,10 @@
         <p>{{ answer }}</p>
     </div>
     <form method="post" action="{{ url_for('respond') }}" class="response-form">
-        <input type="hidden" name="answer" value="{{ answer }}">
         <label for="response">Deine Antwort</label>
         <textarea name="response" id="response" rows="3" placeholder="Reply to the answer" required></textarea>
         <button type="submit">Send</button>
     </form>
-    {% endif %}
-    {% if user_response %}
-    <div class="user-response">
-        <h2>Your Response</h2>
-        <p>{{ user_response }}</p>
-    </div>
     {% endif %}
 </div>
 </body>


### PR DESCRIPTION
## Summary
- add session based chat history for queries
- show the chat history in the template
- include history in follow-up responses
- tweak styles for the chat history
- document chat capability

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685e58f832b48325b647ef832190966f