### PR TITLE
Enable multi-turn chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ reachable.
 ## Web Interface
 
 The repository contains a small Flask application in `app.py` for uploading
-PDFs and submitting questions. Uploaded documents are chunked and embedded and
-stored in Qdrant. Questions can then be asked against this vector store. The
- web interface now exposes **three** separate forms: one for uploading a document,
- one for sending a query and one for replying to the generated answer.
+PDFs and submitting questions. Uploaded documents are chunked, embedded and
+stored in Qdrant. Questions can then be asked against this vector store.
+The web interface exposes **three** forms: one for uploading a document, one
+for sending a query and one for replying to the generated answer. Replies are
+added to a persistent chat history which is shown in a ChatGPT-like layout and
+sent as additional context for follow-up questions. A simple loading bar gives
+visual feedback while the application processes a request.
 
 To
 run the web app install the dependencies and start the server:

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,23 @@
+// Show a simple loading bar during form submissions
+function startLoading() {
+    const bar = document.getElementById('loading-container');
+    if (bar) {
+        bar.style.display = 'block';
+    }
+}
+
+function stopLoading() {
+    const bar = document.getElementById('loading-container');
+    if (bar) {
+        bar.style.display = 'none';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    stopLoading();
+    document.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', () => {
+            startLoading();
+        });
+    });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -64,12 +64,6 @@ button:hover {
     background-color: var(--accent-color);
 }
 
-.answer {
-    margin-top: 20px;
-    background: #eef;
-    padding: 15px;
-    border-radius: 4px;
-}
 
 .error {
     margin-top: 20px;
@@ -95,4 +89,54 @@ textarea {
     background: #efe;
     padding: 15px;
     border-radius: 4px;
+}
+
+.chat-history {
+    margin-top: 20px;
+    background: #fafafa;
+    padding: 15px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.chat-message {
+    margin: 10px 0;
+    padding: 10px;
+    border-radius: 4px;
+    max-width: 80%;
+    clear: both;
+}
+
+.chat-message.user {
+    background: #d0e6ff;
+    margin-left: auto;
+    text-align: right;
+}
+
+.chat-message.assistant {
+    background: #f0f0f0;
+    margin-right: auto;
+}
+
+#loading-container {
+    width: 100%;
+    height: 4px;
+    background: #eee;
+    margin-top: 10px;
+    display: none;
+    overflow: hidden;
+}
+
+#loading-bar {
+    height: 100%;
+    width: 0;
+    background-color: var(--primary-color);
+    animation: loading 2s linear infinite;
+}
+
+@keyframes loading {
+    0% { width: 0; }
+    100% { width: 100%; }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,11 +8,22 @@
 <body>
 <div class="container">
     <h1>Qdrant RAG Demo</h1>
+    <div id="loading-container"><div id="loading-bar"></div></div>
     <form method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data" class="upload-form">
         <label for="document">PDF Document</label>
         <input type="file" name="document" id="document" accept="application/pdf">
         <button type="submit">Upload</button>
     </form>
+
+    {% if chat_history %}
+    <div class="chat-history">
+        {% for msg in chat_history %}
+        <div class="chat-message {{ msg.role }}">
+            <p>{{ msg.content }}</p>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 
     <form method="post" action="{{ url_for('query') }}" class="query-form">
         <label for="query">Prompt</label>
@@ -26,24 +37,14 @@
     </div>
     {% endif %}
 
-    {% if answer %}
-    <div class="answer">
-        <h2>Answer</h2>
-        <p>{{ answer }}</p>
-    </div>
+    {% if chat_history %}
     <form method="post" action="{{ url_for('respond') }}" class="response-form">
-        <input type="hidden" name="answer" value="{{ answer }}">
         <label for="response">Deine Antwort</label>
         <textarea name="response" id="response" rows="3" placeholder="Reply to the answer" required></textarea>
         <button type="submit">Send</button>
     </form>
     {% endif %}
-    {% if user_response %}
-    <div class="user-response">
-        <h2>Your Response</h2>
-        <p>{{ user_response }}</p>
-    </div>
-    {% endif %}
 </div>
+<script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add session based chat history for queries
- show the chat history in the template
- include history in follow-up responses
- tweak styles for the chat history
- document chat capability
- style conversation like ChatGPT and show loading bar while waiting

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685e58f832b48325b647ef832190966f