### PR TITLE
Show chat history inline and auto-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,14 @@ reachable.
 ## Web Interface
 
 The repository contains a small Flask application in `app.py` for uploading
-PDFs and submitting questions. Uploaded documents are chunked and embedded and
-stored in Qdrant. Questions can then be asked against this vector store. The
- web interface now exposes **three** separate forms: one for uploading a document,
- one for sending a query and one for replying to the generated answer.
+PDFs and submitting questions. Uploaded documents are chunked, embedded and
+stored in Qdrant. Questions can then be asked against this vector store.
+The web interface exposes **three** forms: one for uploading a document, one
+for sending a query and one for replying to the generated answer. Replies are
+added to a persistent chat history which is shown in a ChatGPT-style layout with
+distinct user and assistant bubbles. A simple loading bar gives visual feedback
+while the application processes a request, and the chat area automatically
+scrolls to the latest message after each interaction.
 
 To
 run the web app install the dependencies and start the server:

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,27 @@
+// Show a simple loading bar during form submissions
+function startLoading() {
+    const bar = document.getElementById('loading-container');
+    if (bar) {
+        bar.style.display = 'block';
+    }
+}
+
+function stopLoading() {
+    const bar = document.getElementById('loading-container');
+    if (bar) {
+        bar.style.display = 'none';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    stopLoading();
+    const chat = document.getElementById('chat-container');
+    if (chat) {
+        chat.scrollTop = chat.scrollHeight;
+    }
+    document.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', () => {
+            startLoading();
+        });
+    });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -8,7 +8,7 @@ body {
     font-family: Arial, sans-serif;
     background-color: var(--background-color);
     margin: 0;
-    padding: 40px;
+    padding: 40px 0;
 }
 
 .container {
@@ -17,8 +17,7 @@ body {
     background: #fff;
     padding: 20px;
     border-radius: 8px;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
 }
 
 label {
@@ -64,12 +63,6 @@ button:hover {
     background-color: var(--accent-color);
 }
 
-.answer {
-    margin-top: 20px;
-    background: #eef;
-    padding: 15px;
-    border-radius: 4px;
-}
 
 .error {
     margin-top: 20px;
@@ -90,9 +83,50 @@ textarea {
     resize: vertical;
 }
 
-.user-response {
+
+#chat-container {
     margin-top: 20px;
-    background: #efe;
-    padding: 15px;
-    border-radius: 4px;
+    max-height: 400px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.chat-message {
+    padding: 12px 15px;
+    border-radius: 8px;
+    max-width: 80%;
+    line-height: 1.4;
+}
+
+.chat-message.user {
+    background: #dcf8c6;
+    margin-left: auto;
+}
+
+.chat-message.assistant {
+    background: #f7f7f8;
+    margin-right: auto;
+}
+
+#loading-container {
+    width: 100%;
+    height: 4px;
+    background: #eee;
+    margin-top: 10px;
+    display: none;
+    overflow: hidden;
+}
+
+#loading-bar {
+    height: 100%;
+    width: 0;
+    background-color: var(--primary-color);
+    animation: loading 2s linear infinite;
+}
+
+@keyframes loading {
+    0% { width: 0; }
+    100% { width: 100%; }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,11 +8,22 @@
 <body>
 <div class="container">
     <h1>Qdrant RAG Demo</h1>
+    <div id="loading-container"><div id="loading-bar"></div></div>
     <form method="post" action="{{ url_for('upload') }}" enctype="multipart/form-data" class="upload-form">
         <label for="document">PDF Document</label>
         <input type="file" name="document" id="document" accept="application/pdf">
         <button type="submit">Upload</button>
     </form>
+
+    {% if chat_history %}
+    <div id="chat-container">
+        {% for msg in chat_history %}
+        <div class="chat-message {{ msg.role }}">
+            <p>{{ msg.content }}</p>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 
     <form method="post" action="{{ url_for('query') }}" class="query-form">
         <label for="query">Prompt</label>
@@ -26,24 +37,14 @@
     </div>
     {% endif %}
 
-    {% if answer %}
-    <div class="answer">
-        <h2>Answer</h2>
-        <p>{{ answer }}</p>
-    </div>
+    {% if chat_history %}
     <form method="post" action="{{ url_for('respond') }}" class="response-form">
-        <input type="hidden" name="answer" value="{{ answer }}">
         <label for="response">Deine Antwort</label>
         <textarea name="response" id="response" rows="3" placeholder="Reply to the answer" required></textarea>
         <button type="submit">Send</button>
     </form>
     {% endif %}
-    {% if user_response %}
-    <div class="user-response">
-        <h2>Your Response</h2>
-        <p>{{ user_response }}</p>
-    </div>
-    {% endif %}
 </div>
+<script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove dedicated chat history panel
- display chat messages inline and scroll to bottom on load
- update styles accordingly and document automatic scrolling
- add ChatGPT-style styling for messages and container

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685e58f832b48325b647ef832190966f