### PR TITLE
Reset chat history on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ while the application processes a request, and the chat area automatically
 scrolls to the latest message after each interaction. The chat history is also
 sent as additional context for follow-up questions.
 
+When the server restarts the session history is reset. After a restart the chat
+shows a single assistant message prompting the user to ask a question.
+
 
 To
 run the web app install the dependencies and start the server:


### PR DESCRIPTION
## Summary
- reset the session if the server restarts
- seed chat with a prompt asking the user to pose a question
- document restart behaviour in the README

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685e68a44fd0832592151f7c2b41993b