### PR TITLE
Add dark chat component

### DIFF
--- a/static/chat_component.css
+++ b/static/chat_component.css
@@ -1,0 +1,65 @@
+body {
+  margin: 0;
+  height: 100vh;
+  background: #1e1e1e;
+  color: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: Arial, sans-serif;
+}
+
+.chat-box {
+  background: #2e2e2e;
+  padding: 20px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.pdf-label {
+  border: 2px dashed #555;
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.3s ease;
+}
+
+.pdf-label.drag {
+  border-color: #888;
+}
+
+.pdf-label input {
+  display: none;
+}
+
+textarea {
+  background: #1e1e1e;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 15px;
+  resize: vertical;
+  min-height: 120px;
+}
+
+button {
+  align-self: flex-end;
+  padding: 10px 16px;
+  background: #4a90e2;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.answer {
+  background: #1e1e1e;
+  color: #fff;
+  padding: 15px;
+  border-radius: 4px;
+  min-height: 60px;
+}

--- a/templates/chat_component.html
+++ b/templates/chat_component.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PDF Chat Component</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='chat_component.css') }}">
+</head>
+<body>
+<div class="chat-wrapper">
+    <form class="chat-box" method="post" action="#" enctype="multipart/form-data">
+        <label for="pdf" class="pdf-label">
+            <span>Drop PDF or click to upload</span>
+            <input id="pdf" type="file" accept="application/pdf">
+        </label>
+        <textarea id="prompt" placeholder="Ask anything..."></textarea>
+        <button type="submit">Send</button>
+        <div id="answer" class="answer"></div>
+    </form>
+</div>
+<script>
+const pdfInput = document.getElementById('pdf');
+const label = document.querySelector('.pdf-label');
+
+label.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    label.classList.add('drag');
+});
+label.addEventListener('dragleave', () => label.classList.remove('drag'));
+label.addEventListener('drop', (e) => {
+    e.preventDefault();
+    pdfInput.files = e.dataTransfer.files;
+    label.classList.remove('drag');
+});
+
+document.querySelector('form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const prompt = document.getElementById('prompt').value;
+    document.getElementById('answer').textContent = 'Result: ' + prompt;
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML snippet with a dark ChatGPT-like upload box for PDF, prompt, and answer
- add matching CSS styles

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685e6a64152c8325898dc09223c8c03e