### PR TITLE
Add timestamps to chat messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import time
 from tempfile import NamedTemporaryFile
+from datetime import datetime
 
 from flask import Flask, render_template, request, redirect, url_for, session
 from werkzeug.utils import secure_filename
@@ -28,7 +29,11 @@ def check_server_restart():
         session.clear()
         session["server_start_time"] = app.config["SERVER_START_TIME"]
         session["chat_history"] = [
-            {"role": "assistant", "content": "Bitte stelle eine Frage."}
+            {
+                "role": "assistant",
+                "content": "Bitte stelle eine Frage.",
+                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            }
         ]
 
 
@@ -65,8 +70,16 @@ def interact():
         try:
             retrieved = retrieve_similar_chunks(query_text, client, COLLECTION_NAME, top_k=5)
             answer = answer_with_context(query_text, retrieved)
-            chat_history.append({"role": "user", "content": query_text})
-            chat_history.append({"role": "assistant", "content": answer})
+            chat_history.append({
+                "role": "user",
+                "content": query_text,
+                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            })
+            chat_history.append({
+                "role": "assistant",
+                "content": answer,
+                "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            })
             session["chat_history"] = chat_history
         except ValueError as e:
             error = str(e)
@@ -79,8 +92,16 @@ def interact():
         )
         context_chunks = retrieved + [history_text]
         answer = answer_with_context(user_response, context_chunks)
-        chat_history.append({"role": "user", "content": user_response})
-        chat_history.append({"role": "assistant", "content": answer})
+        chat_history.append({
+            "role": "user",
+            "content": user_response,
+            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        })
+        chat_history.append({
+            "role": "assistant",
+            "content": answer,
+            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        })
         session["chat_history"] = chat_history
 
     return render_template("index.html", answer=answer, error=error, chat_history=chat_history)

--- a/static/style.css
+++ b/static/style.css
@@ -110,6 +110,12 @@ textarea {
     margin-right: auto;
 }
 
+.timestamp {
+    font-size: 0.75rem;
+    color: #666;
+    margin: 0 0 4px 0;
+}
+
 #loading-container {
     width: 100%;
     height: 4px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     <div id="chat-container">
         {% for msg in chat_history %}
         <div class="chat-message {{ msg.role }}">
+            <p class="timestamp">{{ msg.timestamp }}</p>
             <p>{{ msg.content }}</p>
         </div>
         {% endfor %}
@@ -24,7 +25,7 @@
     <div class="chat-history">
         <h2>Chat History</h2>
         {% for msg in chat_history %}
-        <p><strong>{{ msg.role.capitalize() }}:</strong> {{ msg.content }}</p>
+        <p><strong>{{ msg.role.capitalize() }}:</strong> [{{ msg.timestamp }}] {{ msg.content }}</p>
         {% endfor %}
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- add datestamp generation in `app.py`
- show timestamps in chat message display
- style timestamp text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6fbae0088325b183ada11612f183