### PR TITLE
Add clear chat button to web UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,13 @@ def index():
     return render_template("index.html", answer=None, error=None, chat_history=chat_history)
 
 
+@app.route("/clear_chat", methods=["POST"])
+def clear_chat():
+    """Clear the current chat history."""
+    session.clear()
+    return redirect(url_for("index"))
+
+
 @app.route("/interact", methods=["POST"])
 def interact():
     check_server_restart()

--- a/static/style.css
+++ b/static/style.css
@@ -146,3 +146,7 @@ textarea {
     max-height: 300px;
     overflow-y: auto;
 }
+
+.clear-form {
+    margin-top: 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,10 @@
         <button type="submit">Submit</button>
     </form>
 
+    <form method="post" action="{{ url_for('clear_chat') }}" class="clear-form">
+        <button type="submit">Clear Chat</button>
+    </form>
+
     {% if error %}
     <div class="error">
         <p>{{ error }}</p>


### PR DESCRIPTION
## Summary
- add a form button on the chat page that clears session history
- style the clear form with a small margin
- provide Flask endpoint to handle chat clearing

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685e73423eac83258ced70e798145876