### PR TITLE
Fix alignment of chat form buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -101,7 +101,7 @@ textarea {
 
 #chat-form {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     gap: 10px;
     border-top: 1px solid #eee;
     padding-top: 10px;


### PR DESCRIPTION
## Summary
- fix send/upload button alignment by centering the elements in `#chat-form`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e80e583fc832598d868adda75ee72