### PR TITLE
Add drag-and-drop and align buttons

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -21,10 +21,42 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const fileInput = document.getElementById('document');
     const fileName = document.getElementById('file-name');
+    const dropArea = document.querySelector('.upload-section');
     if (fileInput && fileName) {
+        const updateName = files => {
+            if (files.length) {
+                fileName.textContent = files[0].name;
+            } else {
+                fileName.textContent = '';
+            }
+        };
+
         fileInput.addEventListener('change', () => {
-            fileName.textContent = fileInput.files.length ? fileInput.files[0].name : '';
+            updateName(fileInput.files);
         });
+
+        if (dropArea) {
+            ['dragenter', 'dragover'].forEach(evt => {
+                dropArea.addEventListener(evt, e => {
+                    e.preventDefault();
+                    dropArea.classList.add('drag-over');
+                });
+            });
+
+            ['dragleave', 'drop'].forEach(evt => {
+                dropArea.addEventListener(evt, e => {
+                    e.preventDefault();
+                    dropArea.classList.remove('drag-over');
+                });
+            });
+
+            dropArea.addEventListener('drop', e => {
+                if (e.dataTransfer.files.length) {
+                    fileInput.files = e.dataTransfer.files;
+                    updateName(e.dataTransfer.files);
+                }
+            });
+        }
     }
     document.querySelectorAll('form').forEach(form => {
         form.addEventListener('submit', () => {

--- a/static/style.css
+++ b/static/style.css
@@ -101,7 +101,7 @@ textarea {
 
 #chat-form {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     gap: 10px;
     border-top: 1px solid #eee;
     padding-top: 10px;
@@ -109,10 +109,10 @@ textarea {
 
 .upload-section {
     display: flex;
-    flex-direction: column;
     align-items: center;
+    gap: 8px;
     font-size: 0.75rem;
-    width: 40px;
+    width: auto;
 }
 
 .upload-label {
@@ -127,9 +127,12 @@ textarea {
     cursor: pointer;
 }
 
+.upload-section.drag-over .upload-label {
+    background-color: var(--accent-color);
+}
+
 #file-name {
-    margin-bottom: 4px;
-    text-align: center;
+    margin: 0;
     word-break: break-all;
 }
 


### PR DESCRIPTION
## Summary
- align upload and submit buttons horizontally
- highlight upload button while dragging
- enable drag and drop PDF upload

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e823e3c0883258bca79e789b5e237