### PR TITLE
Add typing indicator for chat

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -19,6 +19,17 @@ document.addEventListener('DOMContentLoaded', () => {
     if (chat) {
         chat.scrollTop = chat.scrollHeight;
     }
+    const typing = document.getElementById('typing-indicator');
+    const showTyping = () => {
+        if (typing) typing.style.display = 'flex';
+    };
+    const hideTyping = () => {
+        if (typing) typing.style.display = 'none';
+    };
+    hideTyping();
+
+    let typingTimeout;
+
     const fileInput = document.getElementById('document');
     const fileName = document.getElementById('file-name');
     const dropArea = document.querySelector('.upload-section');
@@ -60,9 +71,22 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     }
+    const queryInput = document.getElementById('query');
+    if (queryInput) {
+        queryInput.addEventListener('input', () => {
+            if (queryInput.value.trim()) {
+                showTyping();
+                clearTimeout(typingTimeout);
+                typingTimeout = setTimeout(hideTyping, 1000);
+            } else {
+                hideTyping();
+            }
+        });
+    }
     document.querySelectorAll('form').forEach(form => {
         form.addEventListener('submit', () => {
             startLoading();
+            showTyping();
         });
     });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -178,6 +178,29 @@ textarea {
     margin-right: auto;
 }
 
+.typing-indicator {
+    display: none;
+    align-items: center;
+    gap: 4px;
+}
+
+.typing-indicator span {
+    width: 6px;
+    height: 6px;
+    background-color: #999;
+    border-radius: 50%;
+    opacity: 0.4;
+    animation: blink 1.4s infinite both;
+}
+
+.typing-indicator span:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.typing-indicator span:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
 .timestamp {
     font-size: 0.75rem;
     color: #666;
@@ -217,4 +240,9 @@ textarea {
 
 .clear-form {
     margin-top: 10px;
+}
+
+@keyframes blink {
+    0%, 80%, 100% { opacity: 0.4; }
+    40% { opacity: 1; }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,9 @@
                 <p>{{ msg.content }}</p>
             </div>
             {% endfor %}
+            <div id="typing-indicator" class="chat-message assistant typing-indicator">
+                <span></span><span></span><span></span>
+            </div>
         </div>
 
         <form method="post" action="{{ url_for('interact') }}" enctype="multipart/form-data" id="chat-form" class="chat-form">


### PR DESCRIPTION
## Summary
- add HTML container for typing dots
- animate dots using CSS
- toggle typing indicator in JavaScript when user types or submits the form

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e8d2a83548325a4034409f294fa5b