### PR TITLE
Add typing indicators

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -60,9 +60,39 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     }
-    document.querySelectorAll('form').forEach(form => {
-        form.addEventListener('submit', () => {
-            startLoading();
+    const queryInput = document.getElementById('query');
+    const userIndicator = document.getElementById('user-typing-indicator');
+    const assistantIndicator = document.getElementById('assistant-typing-indicator');
+
+    if (queryInput && userIndicator) {
+        queryInput.addEventListener('input', () => {
+            if (queryInput.value) {
+                userIndicator.style.display = 'block';
+            } else {
+                userIndicator.style.display = 'none';
+            }
         });
+    }
+
+    const chatForm = document.getElementById('chat-form');
+    if (chatForm) {
+        chatForm.addEventListener('submit', e => {
+            e.preventDefault();
+            if (assistantIndicator) {
+                assistantIndicator.style.display = 'block';
+            }
+            startLoading();
+            setTimeout(() => {
+                chatForm.submit();
+            }, 10);
+        });
+    }
+
+    document.querySelectorAll('form').forEach(form => {
+        if (form !== chatForm) {
+            form.addEventListener('submit', () => {
+                startLoading();
+            });
+        }
     });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -218,3 +218,31 @@ textarea {
 .clear-form {
     margin-top: 10px;
 }
+
+.typing-indicator {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    line-height: 0;
+}
+
+.typing-indicator .dot {
+    width: 6px;
+    height: 6px;
+    background-color: #888;
+    border-radius: 50%;
+    animation: blink 1s infinite ease-in-out;
+}
+
+.typing-indicator .dot:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.typing-indicator .dot:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+@keyframes blink {
+    0%, 80%, 100% { opacity: 0.2; }
+    40% { opacity: 1; }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,12 @@
                 <p>{{ msg.content }}</p>
             </div>
             {% endfor %}
+            <div id="user-typing-indicator" class="chat-message user typing-indicator" style="display: none;">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+            </div>
+            <div id="assistant-typing-indicator" class="chat-message assistant typing-indicator" style="display: none;">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+            </div>
         </div>
 
         <form method="post" action="{{ url_for('interact') }}" enctype="multipart/form-data" id="chat-form" class="chat-form">


### PR DESCRIPTION
## Summary
- add typing indicator elements to chat page
- implement typing indicator animation in CSS
- show user/assistant typing states in client JS

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685e8e496ac88325a4d7dd0e94beeaa1