### PR TITLE
Improve follow-up query retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ added to a persistent chat history which is shown in a ChatGPT-style layout with
 distinct user and assistant bubbles. A simple loading bar gives visual feedback
 while the application processes a request, and the chat area automatically
 scrolls to the latest message after each interaction. The chat history is also
-sent as additional context for follow-up questions.
+sent as additional context for follow-up questions. When processing a new
+query, the application now retrieves additional context for the previous user
+message by issuing a second lookup against Qdrant.
 
 When the server restarts the session history is reset. After a restart the chat
 shows a single assistant message prompting the user to ask a question.

--- a/app.py
+++ b/app.py
@@ -74,7 +74,22 @@ def interact():
     if message:
         client = get_qdrant_client()
         try:
+            # Retrieve context for the current question
             retrieved = retrieve_similar_chunks(message, client, COLLECTION_NAME, top_k=5)
+
+            # Additionally look up the previous user message when available
+            previous_user_message = None
+            for past in reversed(chat_history):
+                if past.get("role") == "user":
+                    previous_user_message = past.get("content")
+                    break
+
+            if previous_user_message:
+                retrieved_prev = retrieve_similar_chunks(
+                    previous_user_message, client, COLLECTION_NAME, top_k=5
+                )
+                retrieved.extend(retrieved_prev)
+
             if len(chat_history) > 1:
                 history_text = "\n".join(
                     f"{msg['role'].capitalize()}: {msg['content']}" for msg in chat_history


### PR DESCRIPTION
## Summary
- mention that previous user messages are now also searched to build better context
- document this new behaviour in the README

## Testing
- `pytest -q`
- `python -m py_compile app.py Code/qdrant_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685ead98c0988325a347280d8f5cd65f