### PR TITLE
Send entire conversation to RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ distinct user and assistant bubbles. A simple loading bar gives visual feedback
 while the application processes a request, and the chat area automatically
 scrolls to the latest message after each interaction. The chat history is also
 sent as additional context for follow-up questions. When processing a new
-query, the application now retrieves additional context for the previous user
-message by issuing a second lookup against Qdrant.
+query, the application now retrieves additional context for **all** previous
+user messages by issuing lookups against Qdrant for each of them.
 
 When the server restarts the session history is reset. After a restart the chat
 shows a single assistant message prompting the user to ask a question.

--- a/app.py
+++ b/app.py
@@ -77,18 +77,13 @@ def interact():
             # Retrieve context for the current question
             retrieved = retrieve_similar_chunks(message, client, COLLECTION_NAME, top_k=5)
 
-            # Additionally look up the previous user message when available
-            previous_user_message = None
-            for past in reversed(chat_history):
+            # Also look up all previous user messages, not just the last one
+            for past in chat_history:
                 if past.get("role") == "user":
-                    previous_user_message = past.get("content")
-                    break
-
-            if previous_user_message:
-                retrieved_prev = retrieve_similar_chunks(
-                    previous_user_message, client, COLLECTION_NAME, top_k=5
-                )
-                retrieved.extend(retrieved_prev)
+                    retrieved_prev = retrieve_similar_chunks(
+                        past.get("content"), client, COLLECTION_NAME, top_k=5
+                    )
+                    retrieved.extend(retrieved_prev)
 
             if len(chat_history) > 1:
                 history_text = "\n".join(


### PR DESCRIPTION
## Summary
- query Qdrant for every previous user message when generating an answer
- update README about retrieving context for all prior questions

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685eafa16f788325ba600f4a9157eac5