### PR TITLE
Move title sidebar left

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,20 @@ body {
     padding: 40px 0;
 }
 
+.main-layout {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+.title-container {
+    width: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .container {
     max-width: 600px;
     margin: auto;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,9 +6,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-<div class="container">
-    <h1>Qdrant RAG Demo</h1>
-    <div id="loading-container"><div id="loading-bar"></div></div>
+<div class="main-layout">
+    <div class="title-container">
+        <h1>Qdrant RAG Demo</h1>
+    </div>
+    <div class="container">
+        <div id="loading-container"><div id="loading-bar"></div></div>
 
     <div id="chat-interface">
         <div id="chat-container">
@@ -40,6 +43,7 @@
         <p>{{ error }}</p>
     </div>
     {% endif %}
+    </div>
 </div>
 <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- separate the page layout into a sidebar and chat area
- keep chat container centered while moving title container to the left using flexbox

## Testing
- `python -m py_compile app.py Code/qdrant_utils.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685eb36877a483258653134b0a943c47