### PR TITLE
Add experiment notebook for RAG evaluation

### DIFF
--- a/Experiment/experiment.ipynb
+++ b/Experiment/experiment.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RAG Experiment\n",
+    "\n",
+    "This notebook runs two experiments:\n",
+    "1. Query the LLM directly for a set of questions and store the answers.\n",
+    "2. Load PDF documents into Qdrant and re-run the questions using retrieval augmented generation (RAG).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from Code.qdrant_utils import (\n",
+    "    answer_with_context,\n",
+    "    get_qdrant_client,\n",
+    "    load_pdf_and_chunk,\n",
+    "    embed_chunks,\n",
+    "    store_embeddings_in_qdrant,\n",
+    "    retrieve_similar_chunks,\n",
+    ")\n",
+    "\n",
+    "from Experiment.experiment_utils import save_results_to_csv\n",
+    "\n",
+    "DATA_PATH = Path('RAG Paper') / 'question.json'\n",
+    "PDF_DIR = Path('RAG Paper')\n",
+    "GROUND_TRUTH_CSV = Path('Experiment') / 'results_ground_truth.csv'\n",
+    "RAG_CSV = Path('Experiment') / 'results_rag.csv'\n",
+    "COLLECTION_NAME = 'rag_papers'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load evaluation questions\n",
+    "The JSON file contains questions grouped by paper and additional metadata questions.\n",
+    "We flatten them into a single list with their gold answers." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(DATA_PATH, 'r', encoding='utf-8') as f:\n",
+    "    data = json.load(f)['evaluation_dataset']\n",
+    "\n",
+    "questions = []\n",
+    "# content questions per paper\n",
+    "for paper in data['papers']:\n",
+    "    for q in paper.get('questions', []):\n",
+    "        questions.append({\n",
+    "            'question_id': q['question_id'],\n",
+    "            'question': q['question'],\n",
+    "            'answer': q['answer']\n",
+    "        })\n",
+    "\n",
+    "# metadata questions are answered for each paper separately\n",
+    "for meta in data.get('metadata_questions', {}).get('questions', []):\n",
+    "    base_id = meta['question_id']\n",
+    "    text = meta['question']\n",
+    "    for entry in meta.get('papers', []):\n",
+    "        q_id = f\"P{entry['paper_id']}_{base_id}\"\n",
+    "        questions.append({\n",
+    "            'question_id': q_id,\n",
+    "            'question': text,\n",
+    "            'answer': entry['answer']\n",
+    "        })\n",
+    "\n",
+    "len(questions)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment 1: direct LLM answers\n",
+    "Each question is sent to the LLM without any additional context. The answers are saved to *results_ground_truth.csv*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_gt = []\n",
+    "for q in questions:\n",
+    "    llm_answer = answer_with_context(q['question'], [])\n",
+    "    results_gt.append({\n",
+    "        'question_id': q['question_id'],\n",
+    "        'question_string': q['question'],\n",
+    "        'answer_llm': llm_answer,\n",
+    "        'answer_gold': q['answer']\n",
+    "    })\n",
+    "\n",
+    "save_results_to_csv(results_gt, GROUND_TRUTH_CSV)\n",
+    "len(results_gt)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load PDF documents into Qdrant\n",
+    "All PDF files are chunked, embedded and stored in the collection defined above." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = get_qdrant_client()\n",
+    "for pdf in PDF_DIR.glob('*.pdf'):\n",
+    "    chunks = load_pdf_and_chunk(str(pdf))\n",
+    "    embeddings = embed_chunks(chunks)\n",
+    "    store_embeddings_in_qdrant(client, COLLECTION_NAME, chunks, embeddings)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment 2: RAG answers\n",
+    "For each question we retrieve relevant chunks from Qdrant and pass them to the LLM. Results are written to *results_rag.csv*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_rag = []\n",
+    "for q in questions:\n",
+    "    context = retrieve_similar_chunks(q['question'], client, COLLECTION_NAME)\n",
+    "    llm_answer = answer_with_context(q['question'], context)\n",
+    "    results_rag.append({\n",
+    "        'question_id': q['question_id'],\n",
+    "        'question_string': q['question'],\n",
+    "        'answer_llm': llm_answer,\n",
+    "        'answer_gold': q['answer']\n",
+    "    })\n",
+    "\n",
+    "save_results_to_csv(results_rag, RAG_CSV)\n",
+    "len(results_rag)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3", 
+   "language": "python", 
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python", 
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Experiment/experiment_utils.py
+++ b/Experiment/experiment_utils.py
@@ -1,0 +1,24 @@
+import csv
+from typing import List, Dict
+
+
+def save_results_to_csv(results: List[Dict[str, str]], filepath: str) -> None:
+    """Save experiment results to a CSV file.
+
+    Parameters
+    ----------
+    results:
+        List of dictionaries containing question_id, question_string,
+        answer_llm and answer_gold.
+    filepath:
+        Destination path for the CSV file.
+    """
+    if not results:
+        return
+
+    fieldnames = ["question_id", "question_string", "answer_llm", "answer_gold"]
+    with open(filepath, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in results:
+            writer.writerow({k: row.get(k, "") for k in fieldnames})


### PR DESCRIPTION
## Summary
- add experiment utilities for CSV result writing
- create experiment notebook to evaluate LLM answers with and without RAG

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68710aae2b8c8330a8d175ce0c4246fd