### PR TITLE
Add notebook for evaluation plots

### DIFF
--- a/evaluation_graphics.ipynb
+++ b/evaluation_graphics.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluation Graphics\n",
+    "This notebook compares evaluation metrics from `results_ground_truth.csv` and `results_rag.csv`.\n",
+    "The goal is to visualize how the RAG approach performs across precision, recall and ROUGE metrics for each question and each paper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pathlib import Path\n",
+    "sns.set(style='whitegrid')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the csv files\n",
+    "base = Path('Experiment')\n",
+    "rag = pd.read_csv(base / 'results_rag.csv')\n",
+    "gt = pd.read_csv(base / 'results_ground_truth.csv')\n",
+    "metric_cols = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract document and question information\n",
+    "def add_doc_question(df):\n",
+    "    df['document'] = df['question_id'].str.split('_').str[0]\n",
+    "    df['question'] = df['question_id'].str.split('_').str[1:].str.join('_')\n",
+    "    return df\n",
+    "\n",
+    "rag = add_doc_question(rag)\n",
+    "gt = add_doc_question(gt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Merge dataframes for comparison\n",
+    "merged = rag[['question_id','document','question'] + metric_cols].merge(\n",
+    "    gt[['question_id'] + metric_cols], on='question_id', suffixes=('_rag','_gt'))\n",
+    "\n",
+    "for col in metric_cols:\n",
+    "    merged[f'{col}_diff'] = merged[f'{col}_rag'] - merged[f'{col}_gt']\n",
+    "\n",
+    "merged.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Heatmap of Metric Improvements\n",
+    "Each cell shows the improvement (RAG minus Ground Truth) for a metric/question pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_improvement_heatmap(df):\n",
+    "    heat_data = df.set_index('question_id')[[c + '_diff' for c in metric_cols]]\n",
+    "    plt.figure(figsize=(10, len(df)*0.4 + 1))\n",
+    "    sns.heatmap(heat_data, annot=True, cmap='RdYlGn', center=0)\n",
+    "    plt.title('Metric improvement (RAG - Ground Truth)')\n",
+    "    plt.show()\n",
+    "\n",
+    "plot_improvement_heatmap(merged)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bar Chart by Question\n",
+    "Compare each metric for RAG and Ground Truth for a specific question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_question_metrics(df, qid):\n",
+    "    data = df[df['question_id'] == qid]\n",
+    "    to_plot = data[[m + '_rag' for m in metric_cols] + [m + '_gt' for m in metric_cols]].T\n",
+    "    to_plot.index = metric_cols * 2\n",
+    "    to_plot['source'] = ['RAG']*len(metric_cols) + ['Ground Truth']*len(metric_cols)\n",
+    "    plt.figure(figsize=(8,4))\n",
+    "    sns.barplot(x='index', y=0, hue='source', data=to_plot.reset_index())\n",
+    "    plt.title(f'Metrics for {qid}')\n",
+    "    plt.xticks(rotation=45)\n",
+    "    plt.ylabel('score')\n",
+    "    plt.show()\n",
+    "\n",
+    "_ = [plot_question_metrics(merged, q) for q in merged['question_id'].unique()[:3]]  # example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mean Metrics per Document\n",
+    "Aggregated metrics are averaged per paper (P1-P5)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_document_means(df):\n",
+    "    means = df.groupby('document')[[c + '_rag' for c in metric_cols] + [c + '_gt' for c in metric_cols]].mean()\n",
+    "    melted = means.reset_index().melt(id_vars='document', var_name='metric', value_name='score')\n",
+    "    melted['source'] = melted['metric'].apply(lambda x: 'RAG' if x.endswith('_rag') else 'Ground Truth')\n",
+    "    melted['metric'] = melted['metric'].str.replace('_rag','').str.replace('_gt','')\n",
+    "    plt.figure(figsize=(10,5))\n",
+    "    sns.barplot(data=melted, x='document', y='score', hue='source')\n",
+    "    plt.title('Average metrics per document')\n",
+    "    plt.show()\n",
+    "\n",
+    "plot_document_means(merged)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Boxplot of Improvements by Document\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_improvement_boxplot(df):\n",
+    "    diff_cols = [c + '_diff' for c in metric_cols]\n",
+    "    melted = df.melt(id_vars='document', value_vars=diff_cols, var_name='metric', value_name='improvement')\n",
+    "    plt.figure(figsize=(10,5))\n",
+    "    sns.boxplot(data=melted, x='document', y='improvement')\n",
+    "    plt.axhline(0, color='red', linestyle='--')\n",
+    "    plt.title('Distribution of improvements per document')\n",
+    "    plt.show()\n",
+    "\n",
+    "plot_improvement_boxplot(merged)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `evaluation_graphics.ipynb` to visualize evaluation metrics

## Testing
- `pytest -q`
- `python3 - <<'PY'
import json; json.load(open("evaluation_graphics.ipynb"))
print('valid json')
PY`

------
https://chatgpt.com/codex/tasks/task_e_687133e4ea908330ae7adeac838dc0ae