### PR TITLE
Add expanded evaluation notebook

### DIFF
--- a/Experiment/evaluation.ipynb
+++ b/Experiment/evaluation.ipynb
@@ -1,0 +1,244 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Evaluation of RAG Results\n",
+        "This notebook explores evaluation results comparing a baseline model to a RAG system."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import seaborn as sns\n",
+        "import matplotlib.pyplot as plt\n",
+        "from pathlib import Path\n",
+        "\n",
+        "FIGSIZE = (10,5)\n",
+        "COLOR_PRIMARY = '#792EE5'\n",
+        "COLOR_SECONDARY = '#17C3B2'\n",
+        "\n",
+        "sns.set(style='whitegrid', palette=[COLOR_PRIMARY, COLOR_SECONDARY])\n",
+        "base = Path('Experiment')\n",
+        "rag = pd.read_csv(base / 'results_rag.csv')\n",
+        "baseline = pd.read_csv(base / 'results_baseline.csv')\n",
+        "metric_cols = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "for df in (rag, baseline):\n",
+        "    df['paper'] = df['question_id'].str.split('_').str[0]\n",
+        "    df['question'] = df['question_id'].str.split('_').str[1]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## General information\n",
+        "Summary statistics about the evaluation data."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "print('Total questions:', len(rag))\n",
+        "print('Papers:', rag['paper'].unique())\n",
+        "summary = rag[metric_cols].describe()\n",
+        "summary"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Combine baseline and RAG metrics"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "merged = rag[['question_id','paper','question'] + metric_cols].merge(\n",
+        "    baseline[['question_id'] + metric_cols], on='question_id', suffixes=('_rag','_bl'))\n",
+        "for col in metric_cols:\n",
+        "    merged[f'{col}_diff'] = merged[f'{col}_rag'] - merged[f'{col}_bl']\n",
+        "merged.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Overall improvement heatmap\n",
+        "Shows improvement (RAG - Baseline) per metric and question."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "plt.figure(figsize=(FIGSIZE[0]*1.2, len(merged)*0.4))\n",
+        "heat = merged.set_index('question_id')[[c+'_diff' for c in metric_cols]]\n",
+        "sns.heatmap(heat, annot=True, cmap=sns.diverging_palette(240, 10, as_cmap=True), center=0)\n",
+        "plt.title('Metric improvement per question')\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Comparison of all questions for a paper"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def plot_paper_questions(df, paper):\n",
+        "    data = df[df['paper']==paper]\n",
+        "    melted = data.melt(id_vars=['question'],\n",
+        "                       value_vars=[c+'_rag' for c in metric_cols]+[c+'_bl' for c in metric_cols],\n",
+        "                       var_name='metric', value_name='score')\n",
+        "    melted['source'] = melted['metric'].apply(lambda x: 'RAG' if x.endswith('_rag') else 'Baseline')\n",
+        "    melted['metric'] = melted['metric'].str.replace('_rag','').str.replace('_bl','')\n",
+        "    plt.figure(figsize=(FIGSIZE[0]*1.3, FIGSIZE[1]*1.2))\n",
+        "    sns.barplot(data=melted, x='question', y='score', hue='source')\n",
+        "    plt.title(f'Metrics for all questions in {paper}')\n",
+        "    plt.xticks(rotation=45)\n",
+        "    plt.show()\n",
+        "\n",
+        "plot_paper_questions(merged, 'P1')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Comparison of a question across papers"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def plot_question_across_papers(df, question):\n",
+        "    data = df[df['question']==question]\n",
+        "    melted = data.melt(id_vars=['paper'],\n",
+        "                       value_vars=[c+'_rag' for c in metric_cols]+[c+'_bl' for c in metric_cols],\n",
+        "                       var_name='metric', value_name='score')\n",
+        "    melted['source'] = melted['metric'].apply(lambda x: 'RAG' if x.endswith('_rag') else 'Baseline')\n",
+        "    melted['metric'] = melted['metric'].str.replace('_rag','').str.replace('_bl','')\n",
+        "    plt.figure(figsize=(FIGSIZE[0]*1.3, FIGSIZE[1]*1.2))\n",
+        "    sns.barplot(data=melted, x='paper', y='score', hue='source')\n",
+        "    plt.title(f'Metrics for question {question} across papers')\n",
+        "    plt.show()\n",
+        "\n",
+        "plot_question_across_papers(merged, 'Q1')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Individual question metrics"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def plot_question_metrics(df, qid):\n",
+        "    data = df[df['question_id']==qid]\n",
+        "    to_plot = data[[m+'_rag' for m in metric_cols] + [m+'_bl' for m in metric_cols]].T\n",
+        "    to_plot.index = metric_cols*2\n",
+        "    to_plot['source'] = ['RAG']*len(metric_cols) + ['Baseline']*len(metric_cols)\n",
+        "    plt.figure(figsize=FIGSIZE)\n",
+        "    sns.barplot(x=to_plot.index, y=0, hue='source', data=to_plot.reset_index())\n",
+        "    plt.title(f'Metrics for {qid}')\n",
+        "    plt.xticks(rotation=45)\n",
+        "    plt.ylabel('score')\n",
+        "    plt.show()\n",
+        "\n",
+        "for q in merged['question_id']:\n",
+        "    plot_question_metrics(merged, q)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Distribution of improvements"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "diff_cols=[c+'_diff' for c in metric_cols]\n",
+        "plt.figure(figsize=FIGSIZE)\n",
+        "merged[diff_cols].hist(bins=20, figsize=(FIGSIZE[0]*1.5, FIGSIZE[1]*1.5), color=COLOR_PRIMARY)\n",
+        "plt.suptitle('Histogram of metric improvements')\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Correlation between improvements"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "plt.figure(figsize=(FIGSIZE[0]*1.2, FIGSIZE[1]*1.2))\n",
+        "sns.heatmap(merged[diff_cols].corr(), annot=True, cmap=sns.cubehelix_palette(as_cmap=True))\n",
+        "plt.title('Correlation of improvements')\n",
+        "plt.show()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.9"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `evaluation.ipynb` with improved visual analysis
- set central figure size and color scheme in the Qdrant style
- add comparisons across papers and questions plus more plots

## Testing
- `python create_eval_nb.py`

------
https://chatgpt.com/codex/tasks/task_e_687140e39ca48330913016444519f0a4