### PR TITLE
Add evaluation notebook for analyzing RAG results

### DIFF
--- a/Experiment/evaluation.ipynb
+++ b/Experiment/evaluation.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluation of RAG vs Baseline\n",
+    "This notebook evaluates the question answering results stored in `results_baseline.csv` and `results_rag.csv`.\n",
+    "It visualises different metrics to compare the baseline system with the RAG implementation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sns.set(style=\"whitegrid\")\n",
+    "baseline = pd.read_csv(Path('results_baseline.csv'))\n",
+    "rag = pd.read_csv(Path('results_rag.csv'))\n",
+    "\n",
+    "metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2',\n",
+    "           'factual_correctness','completeness','relevance','justification','depth','overall_score']\n",
+    "\n",
+    "for df in (baseline, rag):\n",
+    "    for col in metrics:\n",
+    "        df[col] = pd.to_numeric(df[col], errors='coerce')\n",
+    "    df['paper'] = df['question_id'].str.extract(r'^(..)_')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Average metrics across all questions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "avg_base = baseline[metrics].mean()\n",
+    "avg_rag = rag[metrics].mean()\n",
+    "avg_df = pd.DataFrame({'Baseline': avg_base, 'RAG': avg_rag})\n",
+    "ax = avg_df.plot(kind='bar', figsize=(12,4))\n",
+    "ax.set_ylabel('Score')\n",
+    "ax.set_title('Average metrics across all questions')\n",
+    "for p in ax.patches:\n",
+    "    height = p.get_height()\n",
+    "    label = f\"{height:.1%}\" if height <= 1 else f\"{height:.1f}\"\n",
+    "    ax.annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8, rotation=0)\n",
+    "plt.xticks(rotation=45, ha='right')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pass/fail counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "pass_base = baseline['pass'].astype(bool).value_counts()\n",
+    "pass_rag = rag['pass'].astype(bool).value_counts()\n",
+    "count_df = pd.DataFrame({'Baseline': pass_base, 'RAG': pass_rag}).fillna(0).T\n",
+    "count_df.columns = ['Fail','Pass']\n",
+    "ax = count_df.plot(kind='bar', stacked=False, figsize=(6,4))\n",
+    "ax.set_ylabel('Count')\n",
+    "ax.set_title('Number of passes and fails')\n",
+    "for c in ax.containers:\n",
+    "    ax.bar_label(c, label_type='edge')\n",
+    "plt.xticks(rotation=0)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Heatmaps of precision/recall/ROUGE per question"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "heat_metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']\n",
+    "fig, axes = plt.subplots(1,2, figsize=(14,8), sharey=True)\n",
+    "vmin = min(baseline[heat_metrics].min().min(), rag[heat_metrics].min().min())\n",
+    "vmax = max(baseline[heat_metrics].max().max(), rag[heat_metrics].max().max())\n",
+    "sns.heatmap(baseline[heat_metrics], ax=axes[0], vmin=vmin, vmax=vmax, cmap='viridis')\n",
+    "axes[0].set_title('Baseline')\n",
+    "sns.heatmap(rag[heat_metrics], ax=axes[1], vmin=vmin, vmax=vmax, cmap='viridis')\n",
+    "axes[1].set_title('RAG')\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel('Metric')\n",
+    "    ax.set_ylabel('Question')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metrics per paper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "for paper, b_group in baseline.groupby('paper'):\n",
+    "    r_group = rag[rag['paper']==paper]\n",
+    "    avg_b = b_group[metrics].mean()\n",
+    "    avg_r = r_group[metrics].mean()\n",
+    "    df = pd.DataFrame({'Baseline': avg_b, 'RAG': avg_r})\n",
+    "    ax = df.plot(kind='bar', figsize=(12,4))\n",
+    "    ax.set_ylabel('Score')\n",
+    "    ax.set_title(f'Average metrics for paper {paper}')\n",
+    "    for p in ax.patches:\n",
+    "        height = p.get_height()\n",
+    "        label = f\"{height:.1%}\" if height <= 1 else f\"{height:.1f}\"\n",
+    "        ax.annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8)\n",
+    "    plt.xticks(rotation=45, ha='right')\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Correlation between LLM-as-judge metrics and n-gram metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "judge_metrics = ['factual_correctness','completeness','relevance','justification','depth']\n",
+    "n_metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']\n",
+    "corr = rag[judge_metrics+n_metrics].corr()\n",
+    "plt.figure(figsize=(10,8))\n",
+    "sns.heatmap(corr, annot=True, fmt='.2f', cmap='coolwarm')\n",
+    "plt.title('Correlation matrix')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Distribution of overall scores\n",
+    "plt.figure(figsize=(6,4))\n",
+    "sns.histplot(baseline['overall_score'], color='b', label='Baseline', kde=True)\n",
+    "sns.histplot(rag['overall_score'], color='orange', label='RAG', kde=True)\n",
+    "plt.legend()\n",
+    "plt.title('Distribution of overall scores')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new `evaluation.ipynb` notebook to evaluate baseline vs RAG results

## Testing
- `python3 -m json.tool Experiment/evaluation.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_687248f995c48330a80aa14b99ccd11d