### PR TITLE
Improve evaluation visuals

### DIFF
--- a/Experiment/evaluation.ipynb
+++ b/Experiment/evaluation.ipynb
@@ -18,17 +18,23 @@
     "import seaborn as sns\n",
     "from pathlib import Path\n",
     "\n",
-    "sns.set(style=\"whitegrid\")\n",
+    "sns.set(style='whitegrid')\n",
+    "palette = {'Baseline': 'tab:blue', 'RAG': 'tab:orange'}\n",
+    "heatmap_cmap = sns.diverging_palette(240, 10, as_cmap=True)\n",
+    "\n",
     "baseline = pd.read_csv(Path('results_baseline.csv'))\n",
     "rag = pd.read_csv(Path('results_rag.csv'))\n",
     "\n",
-    "metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2',\n",
-    "           'factual_correctness','completeness','relevance','justification','depth','overall_score']\n",
+    "ngram_metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']\n",
+    "judge_metrics = ['factual_correctness','completeness','relevance','justification','depth']\n",
+    "metrics = ngram_metrics + judge_metrics\n",
     "\n",
     "for df in (baseline, rag):\n",
-    "    for col in metrics:\n",
+    "    for col in metrics + ['overall_score']:\n",
     "        df[col] = pd.to_numeric(df[col], errors='coerce')\n",
-    "    df['paper'] = df['question_id'].str.extract(r'^(..)_')\n"
+    "    df['paper'] = df['question_id'].str.extract(r'^(..)_')\n",
+    "    df['n_score'] = df[ngram_metrics].mean(axis=1)\n",
+    "    df['judge_score'] = df[judge_metrics].mean(axis=1)\n"
    ]
   },
   {
@@ -42,19 +48,28 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "avg_base = baseline[metrics].mean()\n",
-    "avg_rag = rag[metrics].mean()\n",
-    "avg_df = pd.DataFrame({'Baseline': avg_base, 'RAG': avg_rag})\n",
-    "ax = avg_df.plot(kind='bar', figsize=(12,4))\n",
-    "ax.set_ylabel('Score')\n",
-    "ax.set_title('Average metrics across all questions')\n",
-    "for p in ax.patches:\n",
+    "avg_base_n = baseline[ngram_metrics].mean()\n",
+    "avg_rag_n = rag[ngram_metrics].mean()\n",
+    "avg_base_j = baseline[judge_metrics].mean()\n",
+    "avg_rag_j = rag[judge_metrics].mean()\n",
+    "fig, axes = plt.subplots(1,2, figsize=(14,4))\n",
+    "pd.DataFrame({'Baseline': avg_base_n, 'RAG': avg_rag_n}).plot(kind='bar', ax=axes[0], color=[palette['Baseline'], palette['RAG']])\n",
+    "axes[0].set_ylabel('Score')\n",
+    "axes[0].set_title('Average precision, recall & ROUGE')\n",
+    "for p in axes[0].patches:\n",
     "    height = p.get_height()\n",
-    "    label = f\"{height:.1%}\" if height <= 1 else f\"{height:.1f}\"\n",
-    "    ax.annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8, rotation=0)\n",
-    "plt.xticks(rotation=45, ha='right')\n",
+    "    label = f'{height:.1%}' if height <= 1 else f'{height:.1f}'\n",
+    "    axes[0].annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8)\n",
+    "pd.DataFrame({'Baseline': avg_base_j, 'RAG': avg_rag_j}).plot(kind='bar', ax=axes[1], color=[palette['Baseline'], palette['RAG']])\n",
+    "axes[1].set_title('Average LLM-as-a-judge metrics')\n",
+    "for p in axes[1].patches:\n",
+    "    height = p.get_height()\n",
+    "    label = f'{height:.1%}' if height <= 1 else f'{height:.1f}'\n",
+    "    axes[1].annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8)\n",
+    "for ax in axes:\n",
+    "    ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha='right')\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -72,14 +87,14 @@
     "pass_rag = rag['pass'].astype(bool).value_counts()\n",
     "count_df = pd.DataFrame({'Baseline': pass_base, 'RAG': pass_rag}).fillna(0).T\n",
     "count_df.columns = ['Fail','Pass']\n",
-    "ax = count_df.plot(kind='bar', stacked=False, figsize=(6,4))\n",
+    "ax = count_df.plot(kind='bar', stacked=False, figsize=(6,4), color=[palette['Baseline'], palette['RAG']])\n",
     "ax.set_ylabel('Count')\n",
     "ax.set_title('Number of passes and fails')\n",
     "for c in ax.containers:\n",
     "    ax.bar_label(c, label_type='edge')\n",
     "plt.xticks(rotation=0)\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -93,19 +108,19 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "heat_metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']\n",
+    "heat_metrics = ngram_metrics\n",
     "fig, axes = plt.subplots(1,2, figsize=(14,8), sharey=True)\n",
     "vmin = min(baseline[heat_metrics].min().min(), rag[heat_metrics].min().min())\n",
     "vmax = max(baseline[heat_metrics].max().max(), rag[heat_metrics].max().max())\n",
-    "sns.heatmap(baseline[heat_metrics], ax=axes[0], vmin=vmin, vmax=vmax, cmap='viridis')\n",
+    "sns.heatmap(baseline[heat_metrics], ax=axes[0], vmin=vmin, vmax=vmax, cmap=heatmap_cmap)\n",
     "axes[0].set_title('Baseline')\n",
-    "sns.heatmap(rag[heat_metrics], ax=axes[1], vmin=vmin, vmax=vmax, cmap='viridis')\n",
+    "sns.heatmap(rag[heat_metrics], ax=axes[1], vmin=vmin, vmax=vmax, cmap=heatmap_cmap)\n",
     "axes[1].set_title('RAG')\n",
     "for ax in axes:\n",
     "    ax.set_xlabel('Metric')\n",
     "    ax.set_ylabel('Question')\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -119,21 +134,28 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "for paper, b_group in baseline.groupby('paper'):\n",
+    "papers = sorted(baseline['paper'].unique())\n",
+    "fig, axes = plt.subplots(len(papers), 2, figsize=(14, 4*len(papers)))\n",
+    "for idx, paper in enumerate(papers):\n",
+    "    b_group = baseline[baseline['paper']==paper]\n",
     "    r_group = rag[rag['paper']==paper]\n",
-    "    avg_b = b_group[metrics].mean()\n",
-    "    avg_r = r_group[metrics].mean()\n",
-    "    df = pd.DataFrame({'Baseline': avg_b, 'RAG': avg_r})\n",
-    "    ax = df.plot(kind='bar', figsize=(12,4))\n",
-    "    ax.set_ylabel('Score')\n",
-    "    ax.set_title(f'Average metrics for paper {paper}')\n",
-    "    for p in ax.patches:\n",
-    "        height = p.get_height()\n",
-    "        label = f\"{height:.1%}\" if height <= 1 else f\"{height:.1f}\"\n",
-    "        ax.annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8)\n",
-    "    plt.xticks(rotation=45, ha='right')\n",
-    "    plt.tight_layout()\n",
-    "    plt.show()\n"
+    "    avg_b_n = b_group[ngram_metrics].mean()\n",
+    "    avg_r_n = r_group[ngram_metrics].mean()\n",
+    "    avg_b_j = b_group[judge_metrics].mean()\n",
+    "    avg_r_j = r_group[judge_metrics].mean()\n",
+    "    pd.DataFrame({'Baseline': avg_b_n, 'RAG': avg_r_n}).plot(kind='bar', ax=axes[idx,0], color=[palette['Baseline'], palette['RAG']])\n",
+    "    axes[idx,0].set_ylabel('Score')\n",
+    "    axes[idx,0].set_title(f'Paper {paper} - Precision/Recall/ROUGE')\n",
+    "    pd.DataFrame({'Baseline': avg_b_j, 'RAG': avg_r_j}).plot(kind='bar', ax=axes[idx,1], color=[palette['Baseline'], palette['RAG']])\n",
+    "    axes[idx,1].set_title(f'Paper {paper} - LLM-as-a-judge')\n",
+    "    for ax in axes[idx]:\n",
+    "        for p in ax.patches:\n",
+    "            height = p.get_height()\n",
+    "            label = f'{height:.1%}' if height <= 1 else f'{height:.1f}'\n",
+    "            ax.annotate(label, (p.get_x()+p.get_width()/2., height), ha='center', va='bottom', fontsize=8)\n",
+    "        ax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha='right')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
    ]
   },
   {
@@ -147,14 +169,19 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "judge_metrics = ['factual_correctness','completeness','relevance','justification','depth']\n",
-    "n_metrics = ['precision-1','recall-1','ROUGE-1','precision-2','recall-2','ROUGE-2']\n",
-    "corr = rag[judge_metrics+n_metrics].corr()\n",
-    "plt.figure(figsize=(10,8))\n",
-    "sns.heatmap(corr, annot=True, fmt='.2f', cmap='coolwarm')\n",
-    "plt.title('Correlation matrix')\n",
+    "corr_val = rag['n_score'].corr(rag['judge_score'])\n",
+    "fig, ax1 = plt.subplots(figsize=(10,4))\n",
+    "ax2 = ax1.twinx()\n",
+    "rag['n_score'].plot(kind='bar', ax=ax1, color=palette['Baseline'], label='Avg n-gram')\n",
+    "rag['judge_score'].plot(kind='line', ax=ax2, color=palette['RAG'], marker='o', label='Avg judge')\n",
+    "ax1.set_ylabel('Precision/Recall/ROUGE')\n",
+    "ax2.set_ylabel('LLM-as-judge')\n",
+    "ax1.set_title(f'Per-question correlation (r={corr_val:.2f})')\n",
+    "lines, labels = ax1.get_legend_handles_labels()\n",
+    "lines2, labels2 = ax2.get_legend_handles_labels()\n",
+    "ax1.legend(lines+lines2, labels+labels2, loc='upper right')\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -170,12 +197,47 @@
    "source": [
     "# Distribution of overall scores\n",
     "plt.figure(figsize=(6,4))\n",
-    "sns.histplot(baseline['overall_score'], color='b', label='Baseline', kde=True)\n",
-    "sns.histplot(rag['overall_score'], color='orange', label='RAG', kde=True)\n",
+    "sns.histplot(baseline['overall_score'], color=palette['Baseline'], label='Baseline', kde=True)\n",
+    "sns.histplot(rag['overall_score'], color=palette['RAG'], label='RAG', kde=True)\n",
     "plt.legend()\n",
     "plt.title('Distribution of overall scores')\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### More visualisations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Boxplot of average scores\n",
+    "scores = pd.concat([\n",
+    "    baseline[['n_score','judge_score']].assign(System='Baseline'),\n",
+    "    rag[['n_score','judge_score']].assign(System='RAG')\n",
+    "]).melt(id_vars='System', var_name='Metric', value_name='Score')\n",
+    "plt.figure(figsize=(8,4))\n",
+    "sns.boxplot(data=scores, x='Metric', y='Score', hue='System', palette=[palette['Baseline'], palette['RAG']])\n",
+    "plt.title('Distribution of average metric scores')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Scatter plot with regression line\n",
+    "combined = pd.concat([baseline.assign(System='Baseline'), rag.assign(System='RAG')])\n",
+    "sns.lmplot(data=combined, x='n_score', y='judge_score', hue='System', palette=palette, aspect=1.5)\n",
+    "plt.title('n-gram vs LLM-as-a-judge score')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- adjust evaluation to use consistent colour palette
- split precision/recall/ROUGE bars from LLM-judge metrics
- show per-paper metrics in one figure
- clarify metric correlations with dual‑axis plot
- add boxplot and scatterplot for more visualisation

## Testing
- `python -m json.tool Experiment/evaluation.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_687252d54a5083308a42cb47176bc1de